### PR TITLE
Make DependencyCycleError inherit from RuntimeError.

### DIFF
--- a/jeni.py
+++ b/jeni.py
@@ -32,7 +32,7 @@ class UnsetError(LookupError):
         super(UnsetError, self).__init__(*a, **kw)
 
 
-class DependencyCycleError(LookupError):
+class DependencyCycleError(RuntimeError):
     """Note is not able to be provided, because it depends on itself."""
     def __init__(self, *a, **kw):
         self.notes = kw.pop('notes', None)


### PR DESCRIPTION
Arguably this should be a RuntimeError, because it happens after the
lookup phase.  Previously DependencyCycleErrors would be swallowed by
code that handles UnsetError.