### PR TITLE
Dereference provider instances and cached values in Injector.close().

### DIFF
--- a/jeni.py
+++ b/jeni.py
@@ -642,6 +642,8 @@ class Injector(object):
             # Note: Unable to apply injector on close method.
             finalizer()
         self.closed = True
+        self.instances.clear()
+        self.values.clear()
 
     def prepare_callable(self, fn, partial=False):
         """Prepare arguments required to apply function."""


### PR DESCRIPTION
This had a massive impact in sterling.  Commenting out either of these lines results in thousands of objects being leaked per request.  I'll try to come up with some tests that show the problem.

Other things I tried that had little or no effect:
```diff
--- a/src/python/jeni/jeni.py
+++ b/src/python/jeni/jeni.py
@@ -12,6 +12,7 @@ import functools
 import inspect
 import re
 import sys
+import traceback
 
 import six
 
@@ -97,6 +98,12 @@ class FactoryProvider(Provider):
             raise self.unset_error
         return self.value
 
+    def close(self):
+        if self.unset_error is not None:
+            traceback.clear_frames(self.unset_error.__traceback__)
+        self.value = None
+        self.function = None
+
 
 class GeneratorProvider(Provider):
     """Manage generator lifecycle to implement Provider interface.
@@ -148,10 +155,13 @@ class GeneratorProvider(Provider):
         try:
             next(self.generator)
         except StopIteration:
-            return
+            pass
         else:
             msg = "generator didn't stop: function {!r}"
             raise RuntimeError(msg.format(self.function))
+        self.function = None
+        self.generator = None
+        self.init_value = None
 
 
 def see_doc(obj_with_doc):
@@ -640,6 +650,9 @@ class Injector(object):
         for basenote in reversed(self.get_order):
             # Note: Unable to apply injector on close method.
             self.instances[basenote].close()
         self.instances.clear()
         self.values.clear()
+        self.stats.clear()
         self.closed = True
 
     def prepare_callable(self, fn, partial=False):
```